### PR TITLE
Fix pcre-8.37 Not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NGINX_SOURCE=http://nginx.org/download/nginx-1.9.2.tar.gz
 # URL of OpenSSL source tarball
 OPENSSL_SOURCE=http://www.openssl.org/source/openssl-1.0.1p.tar.gz
 # URL of PCRE source tarball
-PCRE_SOURCE=http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.37.tar.gz
+PCRE_SOURCE=http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.gz
 
 all: nginx/nginx
 


### PR DESCRIPTION
```
wget -O pcre.tar.gz http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.37.tar.gz
--2016-08-06 20:22:46--  http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.37.tar.gz
Resolving ftp.csx.cam.ac.uk (ftp.csx.cam.ac.uk)... 131.111.8.115
Connecting to ftp.csx.cam.ac.uk (ftp.csx.cam.ac.uk)|131.111.8.115|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-08-06 20:22:47 ERROR 404: Not Found.

make: *** [pcre.tar.gz] Error 8
```
