### PR TITLE
Fix invalid with-http_spdy_module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ nginx/nginx: nginx pcre .nginx-patched .openssl-patched
 		--with-cpu-opt=generic --with-pcre=../pcre --with-mail \
 		--with-ipv6 --with-poll_module --with-select_module \
 		--with-select_module --with-poll_module --with-http_ssl_module \
-		--with-http_spdy_module --with-http_realip_module \
+		--with-http_realip_module \
 		--with-http_addition_module --with-http_sub_module \
 		--with-http_dav_module --with-http_flv_module \
 		--with-http_mp4_module --with-http_gunzip_module \


### PR DESCRIPTION
Remove "--with-http_spdy_module"

```
./configure: error: invalid option "--with-http_spdy_module"
make: *** [nginx/nginx] Error 1
```
